### PR TITLE
bugfix for loading Template from URL

### DIFF
--- a/Stencil/Template.swift
+++ b/Stencil/Template.swift
@@ -25,7 +25,7 @@ public class Template {
 
   /// Create a template with a file found at the given URL
   public convenience init(URL:NSURL) throws {
-    try self.init(path: Path(URL.absoluteString))
+    try self.init(path: Path(URL.path!))
   }
 
   /// Create a template with a file found at the given path


### PR DESCRIPTION
NSURL.absoluteString includes "file://", which Path() doesn't expect.